### PR TITLE
Fix for Embedded Non-image Files Glitching the Card Header Display

### DIFF
--- a/src/ccard-block.ts
+++ b/src/ccard-block.ts
@@ -48,7 +48,7 @@ export class ccardProcessor {
     // static
     async docElemStatic(yaml: any) {
         if (yaml.items && (yaml.items instanceof Array)) {
-            let cardBlock = new CardBlock();
+            let cardBlock = new CardBlock(this.app);
             cardBlock.fromYamlCards(yaml);
             const cardsElem = cardBlock.getDocElement(this.app);
             return cardsElem;

--- a/src/folder-brief.ts
+++ b/src/folder-brief.ts
@@ -1,6 +1,11 @@
 
-import { App, MarkdownView, TFile, } from "obsidian";
-import { CardStyle, CardBlock, CardItem } from './card-item'
+import {
+    App,
+    MarkdownView,
+    TFile,
+} from "obsidian";
+
+import {CardBlock, CardItem, CardStyle} from './card-item'
 
 // ------------------------------------------------------------
 // Folder Brief
@@ -11,12 +16,14 @@ export class FolderBrief {
     folderPath: string;
     briefMax: number;
     noteOnly: boolean;
+    imgPrefix: string;
 
     constructor(app: App) {
         this.app = app;
         this.folderPath = '';
         this.briefMax = 64;
         this.noteOnly = false;
+        this.imgPrefix = '';
     }
 
     // for cards type: folder_brief
@@ -27,9 +34,9 @@ export class FolderBrief {
         if (yaml.cards.folder) {
             folderPath = yaml.cards.folder;
             let folderExist = await this.app.vault.adapter.exists(folderPath);
-            if (!folderExist) folderPath = '';
-        }
-        else {
+            if (!folderExist)
+                folderPath = '';
+        } else {
             folderPath = activeFile.parent.path;
         }
 
@@ -37,18 +44,20 @@ export class FolderBrief {
         if (folderPath.length > 0) {
             const view = this.app.workspace.getActiveViewOfType(MarkdownView);
             if (view) {
-                let briefCards = await this.makeBriefCards(folderPath, notePath);
+                let briefCards =
+                    await this.makeBriefCards(folderPath, notePath);
                 const cardsElem = briefCards.getDocElement(this.app);
                 return cardsElem;
             }
         }
         return null;
     }
-    
+
     // generate folder overview
     async makeBriefCards(folderPath: string, activeNotePath: string) {
         // set note name
-        let cardBlock = new CardBlock();
+        let cardBlock = new CardBlock(this.app);
+        this.imgPrefix = cardBlock.imagePrefix;
 
         // children statistic
         let pathList = await this.app.vault.adapter.list(folderPath);
@@ -60,9 +69,11 @@ export class FolderBrief {
             for (var i = 0; i < subFolderList.length; i++) {
                 var subFolderPath = subFolderList[i];
                 // have outside folder note?
-                let noteExists = await this.app.vault.adapter.exists(subFolderPath + '.md');
+                let noteExists =
+                    await this.app.vault.adapter.exists(subFolderPath + '.md');
                 if (!noteExists) {
-                    let folderCard = await this.makeFolderCard(folderPath, subFolderPath);
+                    let folderCard =
+                        await this.makeFolderCard(folderPath, subFolderPath);
                     cardBlock.addCard(folderCard);
                 }
             }
@@ -71,8 +82,10 @@ export class FolderBrief {
         // notes
         for (var i = 0; i < subFileList.length; i++) {
             var subFilePath = subFileList[i];
-            if (!subFilePath.endsWith('.md')) continue;
-            if (subFilePath == activeNotePath) continue; // omit self includeing
+            if (!subFilePath.endsWith('.md'))
+                continue;
+            if (subFilePath == activeNotePath)
+                continue; // omit self including
             let noteCard = await this.makeNoteCard(folderPath, subFilePath);
             cardBlock.addCard(noteCard);
         }
@@ -96,14 +109,14 @@ export class FolderBrief {
 
         // footnote, use date in the future
         card.setFootnote(subFolderPath.replace(folderPath + '/', ''));
-        
+
         // return
         return card;
     }
 
     // make note brief card
     async makeNoteCard(folderPath: string, notePath: string) {
-        // titile
+        // title
         var noteName = notePath.split('/').pop();
         var noteTitle = noteName.substring(0, noteName.length - 3);
         let card = new CardItem(noteTitle, CardStyle.Note);
@@ -117,11 +130,11 @@ export class FolderBrief {
             // console.log(content);
 
             // image
-            var imageUrl = this.getContentImage(contentOrg, folderPath);
+            var imageUrl = await this.getContentImage(contentOrg, folderPath);
             if (imageUrl.length > 0) {
                 card.setHeadImage(imageUrl);
             }
-            
+
             // content?
             var contentBrief = this.getContentBrief(contentOrg);
             if (contentBrief.length > 0) {
@@ -137,8 +150,7 @@ export class FolderBrief {
             if (fileSt.stat) {
                 let date = new Date(fileSt.stat.mtime);
                 card.setFootnote(date.toLocaleString());
-            }
-            else {
+            } else {
                 card.setFootnote(notePath.replace(folderPath + '/', ''));
             }
         }
@@ -147,35 +159,62 @@ export class FolderBrief {
         return card;
     }
 
-    getContentImage(contentOrg: string, folderPath: string) {
+    async getContentImage(contentOrg: string, folderPath: string) {
         var imageUrl = '';
-        // for patten: ![xxx.png]
+        // for pattern: ![name](xyz.png)
         let regexImg = new RegExp('!\\[(.*?)\\]\\((.*?)\\)');
         var match = regexImg.exec(contentOrg);
         if (match != null) {
             imageUrl = match[2];
-        }
-        else {
-            // for patten: ![[xxx.png]]
+        } else {
+            // for pattern: ![[xxx.png]]
             let regexImg2 = new RegExp('!\\[\\[(.*?)\\]\\]');
             match = regexImg2.exec(contentOrg);
-            if (match != null) imageUrl = match[1];
+            if (match != null)
+                imageUrl = match[1];
         }
         // add image url
         if (imageUrl.length > 0) {
-            if (!imageUrl.startsWith('http')) {
-                let headPath = folderPath;
-                let relativePath = false;
-                while (imageUrl.startsWith('../')) {
-                    imageUrl = imageUrl.substring(3);
-                    headPath = headPath.substring(0, headPath.lastIndexOf('/'));
-                    relativePath = true;
+            // only go through setting a real image url if it's in the
+            // settings-defined attachments folder
+            if (imageUrl.includes('#') || imageUrl.includes('^')) {
+                imageUrl = '';
+            } else if (imageUrl.startsWith('http')) {
+                imageUrl = '';
+            } else if (imageUrl.startsWith('file://')) {
+                imageUrl = '';
+            } else if (imageUrl.startsWith('app://')) {
+                imageUrl = '';
+            } else {
+                // if it's a short path or absolute path, try and shortcut the
+                // process by seeing if it's an absolute path to a file in the
+                // user-defined attachments folder
+                let fullPath = this.imgPrefix + '/' + imageUrl;
+                let inDirShort = await this.app.vault.adapter.exists(fullPath);
+                let inDirAbs = await this.app.vault.adapter.exists(imageUrl);
+                if (inDirShort) {
+                    imageUrl = fullPath;
+                    // and if it's not, that means it should be a relative path,
+                    // containing '../'
+                } else if (inDirAbs) {
+                    // we're all set
+                } else if (imageUrl.includes('../') ||
+                           imageUrl.includes('%20')) {
+                    let headPath = folderPath;
+                    let relativePath = false;
+                    while (imageUrl.startsWith('../')) {
+                        imageUrl = imageUrl.substring(3);
+                        headPath =
+                            headPath.substring(0, headPath.lastIndexOf('/'));
+                        relativePath = true;
+                    }
+                    if (relativePath) {
+                        imageUrl = headPath + '/' + imageUrl;
+                    }
+                    imageUrl = imageUrl.replace(/\%20/g, ' ');
+                } else {
+                    imageUrl = '';
                 }
-                if (relativePath) {
-                    imageUrl = headPath + '/' + imageUrl;
-                }
-                imageUrl = imageUrl.replace(/\%20/g, ' ')
-                // imageUrl = this.app.vault.adapter.getResourcePath(imageUrl);
             }
         }
         return imageUrl;
@@ -186,39 +225,41 @@ export class FolderBrief {
         var content = contentOrg.trim();
 
         // skip yaml head
-        if (content.startsWith('---\r') || content.startsWith('---\n') ) {
+        if (content.startsWith('---\r') || content.startsWith('---\n')) {
             const hPos2 = content.indexOf('---', 4);
-            if (hPos2 >= 0 && (content[hPos2-1] == '\n' || (content[hPos2-1] == '\r'))) {
-                content = content.substring(hPos2+4).trim();
+            if (hPos2 >= 0 &&
+                (content[hPos2 - 1] == '\n' || (content[hPos2 - 1] == '\r'))) {
+                content = content.substring(hPos2 + 4).trim();
             }
         }
 
-        content = content
-        // Remove YAML code
-        // .replace(/^---[\r\n][^(---)]*[\r\n]---[\r\n]/g, '')
-        // Remove HTML tags
-        .replace(/<[^>]*>/g, '')
-        // wiki style links
-        .replace(/\!\[\[(.*?)\]\]/g, '')
-        .replace(/\[\[(.*?)\]\]/g, '$1')
-        // Remove images
-        .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, '')
-        // Remove inline links
-        .replace(/\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
-        // Remove emphasis (repeat the line to remove double emphasis)
-        .replace(/([\*_]{1,3})(\S.*?\S{0,1})\1/g, '$2')
-        // Remove blockquotes
-        .replace(/\n(&gt;|\>)(.*)/g, '')
-        // Remove code blocks
-        .replace(/(```[^\s]*\n[\s\S]*?\n```)/g, '')
-        // Remove inline code
-        .replace(/`(.+?)`/g, '$1')
-        .trim()
+        content =
+            content
+                // Remove YAML code
+                // .replace(/^---[\r\n][^(---)]*[\r\n]---[\r\n]/g, '')
+                // Remove HTML tags
+                .replace(/<[^>]*>/g, '')
+                // wiki style links
+                .replace(/\!\[\[(.*?)\]\]/g, '')
+                .replace(/\[\[(.*?)\]\]/g, '$1')
+                // Remove images
+                .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, '')
+                // Remove inline links
+                .replace(/\[(.*?)\][\[\(].*?[\]\)]/g, '$1')
+                // Remove emphasis (repeat the line to remove double emphasis)
+                .replace(/([\*_]{1,3})(\S.*?\S{0,1})\1/g, '$2')
+                // Remove blockquotes
+                .replace(/\n(&gt;|\>)(.*)/g, '')
+                // Remove code blocks
+                .replace(/(```[^\s]*\n[\s\S]*?\n```)/g, '')
+                // Remove inline code
+                .replace(/`(.+?)`/g, '$1')
+                .trim()
 
         // try to get the first paragraph
         var contentBrief = '';
         content = '\n' + content + '\n';
-        let regexP1 = new RegExp('\n([^\n|^#|^>])([^\n]+)\n', 'g'); 
+        let regexP1 = new RegExp('\n([^\n|^#|^>])([^\n]+)\n', 'g');
         var match = null;
         if ((match = regexP1.exec(content)) !== null) {
             contentBrief = match[1] + match[2];
@@ -237,7 +278,8 @@ export class FolderBrief {
                 }
             }
             if (contentBrief.endsWith(', ')) {
-                contentBrief = contentBrief.substring(0, contentBrief.length-2);
+                contentBrief =
+                    contentBrief.substring(0, contentBrief.length - 2);
             }
         }
 


### PR DESCRIPTION
Well... I got bored/motivated today and managed to squash this bug. I tested what I believe are all of the cases for the `imagePrefix` (attachments folder) on my own machine:
1. Short Path
  - e.g., `![[img.png]]`, located in `<img-prefix-folder>/img.png`
3. Absolute Path
  - e.g., `![[<img-prefix-folder>/img.png]]`, located in `<img-prefix-folder>/img.png`
1. Markdown Link
  - e.g., `![pointless-name](<img-prefix-folder>/big%20red%20firetruck.png)`, located in `<img-prefix-folder>/big red firetruck.png`

I haven't worked in Typescript or with the Obsidian API before, so I'd certainly give things a look to make sure I didn't screw up in any major ways. I also don't know whether this solution is portable to mobile os, since I'm not aware of the salient concerns.

As it is, I'm following what appears to be @xpgo's convention of not considering images that are not a) in the user's settings-specified attachments folder, or b) in the specified folder in the `ccard` code block as `imagePrefix: 'attachments/'`, since that seems to avoid a large number of headaches.

Anyway, I really appreciate your work putting this .plugin together, and hopefully this works out

Fixes #43 (and #37)
