### PR TITLE
fix preview-images with alt-text / "outside"-method

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@rollup/plugin-typescript": "^6.0.0",
+    "@rollup/plugin-typescript": "^6.1.0",
     "@types/node": "^14.14.30",
     "@types/yaml": "^1.9.7",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.39.0",
-    "tslib": "^2.0.3",
-    "typescript": "^4.1.5",
+    "tslib": "^2.6.2",
+    "typescript": "^4.9.5",
     "yaml": "^1.10.0"
   }
 }

--- a/src/ccard-block.ts
+++ b/src/ccard-block.ts
@@ -72,7 +72,7 @@ export class ccardProcessor {
         if (folderPath.length > 0) {
             const view = this.app.workspace.getActiveViewOfType(MarkdownView);
             if (view) {
-                let folderBrief = new FolderBrief(this.app);
+                let folderBrief = new FolderBrief(this.app, folderNote.method);
 
                 // brief options
                 if (yaml.briefMax) {

--- a/src/folder-brief.ts
+++ b/src/folder-brief.ts
@@ -6,17 +6,23 @@ import { CardStyle, CardBlock, CardItem } from './card-item'
 // Folder Brief
 // ------------------------------------------------------------
 
+enum NoteFileMethod {
+    Index, Inside, Outside,
+}
+
 export class FolderBrief {
     app: App;
     folderPath: string;
     briefMax: number;
     noteOnly: boolean;
+    method: NoteFileMethod;
 
-    constructor(app: App) {
+    constructor(app: App, method: NoteFileMethod) {
         this.app = app;
         this.folderPath = '';
         this.briefMax = 64;
         this.noteOnly = false;
+        this.method = method;
     }
 
     // for cards type: folder_brief
@@ -156,8 +162,8 @@ export class FolderBrief {
             imageUrl = match[2];
         }
         else {
-            // for patten: ![[xxx.png]]
-            let regexImg2 = new RegExp('!\\[\\[(.*?)\\]\\]');
+            // for patten: ![[xxx.png]] or ![[xxx.png|style/size]] → "xxx.png"
+            let regexImg2 = new RegExp('!\\[\\[(.*?)(\\|[^|]*)?\\]\\]');
             match = regexImg2.exec(contentOrg);
             if (match != null) imageUrl = match[1];
         }
@@ -171,7 +177,8 @@ export class FolderBrief {
                     headPath = headPath.substring(0, headPath.lastIndexOf('/'));
                     relativePath = true;
                 }
-                if (relativePath) {
+                // folder-note "outside" still needs headPath added
+                if (relativePath || this.method == NoteFileMethod.Outside) {
                     imageUrl = headPath + '/' + imageUrl;
                 }
                 imageUrl = imageUrl.replace(/\%20/g, ' ')

--- a/src/folder-note.ts
+++ b/src/folder-note.ts
@@ -250,7 +250,7 @@ export class FolderNote {
             .replace(/{{FOLDER_PATH}}/g, this.folderPath)
         // keyword: {{FOLDER_BRIEF}}
         if (content.contains('{{FOLDER_BRIEF}}')) {
-            let folderBrief = new FolderBrief(this.app);
+            let folderBrief = new FolderBrief(this.app, this.method);
             let briefCards = await folderBrief.makeBriefCards(this.folderPath, this.notePath);
             content = content.replace('{{FOLDER_BRIEF}}', briefCards.getYamlCode());
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,13 +78,12 @@ export default class FolderNotePlugin extends Plugin {
             callback: async () => {
                 const view = this.app.workspace.getActiveViewOfType(MarkdownView);
                 if (view) {
-                    const editor = view.sourceMode.cmEditor;
                     const activeFile = this.app.workspace.getActiveFile();
                     // generate brief
-                    let folderBrief = new FolderBrief(this.app);
+                    let folderBrief = new FolderBrief(this.app, await this.folderNote.method);
                     let folderPath = await this.folderNote.getNoteFolderBriefPath(activeFile.path);
                     let briefCards = await folderBrief.makeBriefCards(folderPath, activeFile.path);
-                    editor.replaceSelection(briefCards.getYamlCode(), "end");
+                    view.editor.replaceSelection(briefCards.getYamlCode(), "end");
                 }
             },
             hotkeys: []


### PR DESCRIPTION
Similar to #79 in affected areas - but way more lightweight.

Problems i had:
- Images with alt-text got selected, but linked incorrectly.
- As i use "outside" as method the folder-path was always missing

solution:
- drag `method` into FolderBrief-constructor
- cut off `|` and everything after in `[[…]]`-links
- `view.sourceMode.cmEditor` does not exist anymore in obsidian-api-master and moved to `view.editor`. Both work in my version, but typescript kept complaining until i fixed it :grin: 

compiled it with `rollup` and it worked for me.
